### PR TITLE
Fix Mermaid diagram rendering on GitHub

### DIFF
--- a/learning/DESIGN.md
+++ b/learning/DESIGN.md
@@ -165,7 +165,7 @@ graph TB
     end
     
     subgraph API["API Layer (Next.js API Routes)"]
-        Route[/api/socratic-dialogue<br/>• RAG retrieval<br/>• LLM prompt construction<br/>• Mastery assessment]
+        Route[API: socratic-dialogue<br/>- RAG retrieval<br/>- LLM prompt construction<br/>- Mastery assessment]
     end
     
     subgraph Data["Data Layer"]
@@ -252,15 +252,15 @@ Embedding Generation (embed-chunks.ts)
 
 ```mermaid
 graph TB
-    Start([User Input]) --> API[API Route<br/>/api/socratic-dialogue]
-    API --> Load[Load Data<br/>• Concept info<br/>• Cached textbook context]
+    Start([User Input]) --> API[API Route<br/>socratic-dialogue]
+    API --> Load[Load Data<br/>- Concept info<br/>- Cached textbook context]
     Load --> RAG{First turn?}
-    RAG -->|Yes| Retrieve[RAG Retrieval<br/>• Embed query<br/>• Cosine similarity<br/>• Top-K chunks]
+    RAG -->|Yes| Retrieve[RAG Retrieval<br/>- Embed query<br/>- Cosine similarity<br/>- Top-K chunks]
     RAG -->|No| Build
-    Retrieve --> Build[Build Prompt<br/>• Learning objectives<br/>• Textbook passages<br/>• Conversation history]
+    Retrieve --> Build[Build Prompt<br/>- Learning objectives<br/>- Textbook passages<br/>- Conversation history]
     Build --> Gemini[Gemini 2.5 Flash]
-    Gemini --> Parse[Parse JSON Response<br/>• message<br/>• mastery_assessment]
-    Parse --> UI[Update UI<br/>• Show message<br/>• Update progress bar<br/>• Enable mastery button]
+    Gemini --> Parse[Parse JSON Response<br/>- message<br/>- mastery_assessment]
+    Parse --> UI[Update UI<br/>- Show message<br/>- Update progress bar<br/>- Enable mastery button]
     UI -.->|Next turn| Start
     
     style Start fill:#add8e6


### PR DESCRIPTION
- Replace Unicode bullet points (•) with ASCII hyphens (-)
- Remove forward slash from API route labels that breaks parser
- Fix "Lexical error on line 9" in architecture diagram
- Fix bullet points in runtime flow diagram
- Both diagrams now render correctly on GitHub

GitHub's Mermaid renderer is more restrictive than local tools and requires ASCII-only characters in node labels for reliable parsing.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
